### PR TITLE
Set version to 1.5.22 and use PyPI sdist

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,8 +1,8 @@
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+python_min:
+- '3.10'

--- a/README.md
+++ b/README.md
@@ -98,12 +98,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -130,7 +130,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/lightly-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,13 @@
 {% set name = "lightly" %}
-{% set version = "1.15.22" %}
+{% set version = "1.5.22" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  # Must use GitHub instead of PyPI
-  # https://github.com/lightly-ai/lightly/issues/1146
-  url: https://github.com/lightly-ai/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 33c2dbf33e968a4926f81a5a759346e8198dbb6e4a11354a1e7d7b75820710f9
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/lightly-{{ version }}.tar.gz
+  sha256: 7bb8939976ea5e8fabb20d049812700d51e44f6461f15510a784afd1252a3dbd
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/lightly-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/lightly-{{ version }}.tar.gz
   sha256: 7bb8939976ea5e8fabb20d049812700d51e44f6461f15510a784afd1252a3dbd
 
 build:
@@ -16,12 +16,12 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python {{ python_min }}
     - pip
     - setuptools >=21
     - setuptools-scm
   run:
-    - python >=3.6
+    - python >={{ python_min }}
     - certifi >=14.05.14
     - hydra-core >=1.0.0
     - lightly-utils >=0.0.0,<0.1.dev0
@@ -44,6 +44,7 @@ test:
     - pip check
   requires:
     - pip
+    - python {{ python_min }}
 
 about:
   home: https://github.com/lightly-ai/lightly


### PR DESCRIPTION
https://github.com/lightly-ai/lightly/issues/1146 has been resolved, and source distribution is now at https://pypi.org/project/lightly/1.5.22/#files.

Note version change from 1.15.22 to 1.5.22 to resolve https://github.com/conda-forge/terratorch-feedstock/pull/18/files#r2739402292. Not sure why tag on GitHub is different to that on PyPI.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Also closes #42 as CFEP-25 syntax is applied now.