### PR TITLE
Backfill lightly 1.5.21

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lightly" %}
-{% set version = "1.5.24" %}
+{% set version = "1.5.21" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/lightly-{{ version }}.tar.gz
-  sha256: 86b7d53146cb7b404a5d27f63b647a3fb34e2a1ea05bc231c6a188dd26dfffce
+  sha256: 3f04032c1378ba79b581b7506a6d38ae580efddefbe77bd1a9b0a0d1bdf1d457
 
 build:
   noarch: python


### PR DESCRIPTION
## Summary

Backfill `lightly` 1.5.21 from the PyPI sdist.

## Context

The previous `1.15.21` conda artifact came from an incorrect GitHub tag (`v1.15.21` instead of `v1.5.21`). PyPI has the correct `lightly 1.5.21` sdist, and the current feedstock already uses PyPI sdists.

Related cleanup should mark the incorrect `1.15.21` and `1.15.22` conda artifacts as broken through `conda-forge/admin-requests`: https://github.com/conda-forge/admin-requests/pull/2149

The goal is to publish the missing valid conda package `lightly 1.5.21`; it is not intended to downgrade the default feedstock branch. We will revert this change to the latest once the v1.5.21 is rebuilt.

## Changes

- Set `version` to `1.5.21`.
- Set the source hash to the PyPI sdist hash: `3f04032c1378ba79b581b7506a6d38ae580efddefbe77bd1a9b0a0d1bdf1d457`.