### PR TITLE
Restore version to 1.5.24 after 1.5.21 backfill

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lightly" %}
-{% set version = "1.5.21" %}
+{% set version = "1.5.24" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/lightly-{{ version }}.tar.gz
-  sha256: 3f04032c1378ba79b581b7506a6d38ae580efddefbe77bd1a9b0a0d1bdf1d457
+  sha256: 86b7d53146cb7b404a5d27f63b647a3fb34e2a1ea05bc231c6a188dd26dfffce
 
 build:
   noarch: python


### PR DESCRIPTION
Reverts the temporary version downgrade from #53.

PR #53 intentionally set the recipe to `1.5.21` to **backfill** that version on conda-forge (it had previously only existed under the mislabeled `1.15.21`). Now that `lightly-1.5.21-pyhd8ed1ab_0.conda` is published, this restores `main` to the latest release (`1.5.24`) so the feedstock HEAD reflects the current version again.

Build number stays at 0; CI will rebuild `1.5.24/0`, find the identical artifact already on the channel, and skip re-uploading.